### PR TITLE
ci: fix workflow to be executed on main instead master

### DIFF
--- a/.github/workflows/snake.yml
+++ b/.github/workflows/snake.yml
@@ -8,7 +8,7 @@ on:
 
   push:
     branches:
-      - master
+      - main
 
 jobs:
   generate:


### PR DESCRIPTION
Just change the master branch (from the template) to main.